### PR TITLE
Add Hackathon Organizer Checklist & Resources

### DIFF
--- a/resources/catering_requirements.md
+++ b/resources/catering_requirements.md
@@ -1,0 +1,13 @@
+### Requirements for Ordering Catering
+
+- [ ] Pizza (order 2 slices per person, order 1-2 gluten, vegan, lactose-free. Check Registration for any other dietary restrictions)
+- [ ] Soda (order for 1-2 cans per person, go heavier on the diet soda)
+- [ ] Water (if no water on site, order 1-2 bottles per person)
+- [ ] Cupcakes (order 1 1/2 per person, 6 gluten-free, 6 vegan) or Cookies (order 1 1/2 per person).
+           
+### Other Considerations:
+
+- [ ] If food is to be picked up, make sure the person picking up knows how far away the venue is, and give them enough time for travel
+- [ ] Local favorites may be better than pizza. (Also, may want to try taco bar or deli sandwiches).
+- [ ] Make sure we can change the order at the last minute. We get lots of changes the day of the event.
+- [ ] Make sure to get any dietary requirements from HospitalRun volunteers who haven't registered & count them in the final numbers

--- a/resources/catering_requirements.md
+++ b/resources/catering_requirements.md
@@ -1,13 +1,27 @@
 ### Requirements for Ordering Catering
 
-- [ ] Pizza (order 2 slices per person, order 1-2 gluten, vegan, lactose-free. Check Registration for any other dietary restrictions)
-- [ ] Soda (order for 1-2 cans per person, go heavier on the diet soda)
-- [ ] Water (if no water on site, order 1-2 bottles per person)
-- [ ] Cupcakes (order 1 1/2 per person, 6 gluten-free, 6 vegan) or Cookies (order 1 1/2 per person).
+Hackathons usually span 2 days. We provide lunch and dinner both days, which means 4 meals in total. 
+
+*Important: make sure to collect any information around dietary restrictions before the event, so you can plan accordingly. No one should go hungry at our event!*
+
+Meal ideas:
+- [ ] Pizza (order 2 slices per person, order 1-2 gluten, vegan, lactose-free)
+- [ ] Tacos (usually a taco bar is better, you can order per person and allow for gluten free and vegan options)
+- [ ] Deli platters (make sure to have gluten free bread and something for vegetarians/vegans besides salad)
+- [ ] Local favorites (make sure to poke around for something that highlights the awesome food of the area)
+
+Snack ideas:
+- [ ] Chips (individual sized bags allow for more variety and are more sanitary)
+- [ ] Veggie trays (if you have a lot of vegetarians, this is nice to offer)
+- [ ] Cookies/Cupcakes (people love sugar, order 1 1/2 cupcakes per person, or 2-3 cookies per person, and don't forget GF and vegan options)
+
+Beverages:
+- [ ] Sodas (order for 3-4 cans per person, per day, go heavier on the diet soda, and make sure to have a variety)
+- [ ] Water (if no water on site, order 3-4 bottles per person, per day)
+
            
 ### Other Considerations:
 
 - [ ] If food is to be picked up, make sure the person picking up knows how far away the venue is, and give them enough time for travel
-- [ ] Local favorites may be better than pizza. (Also, may want to try taco bar or deli sandwiches).
 - [ ] Make sure we can change the order at the last minute. We get lots of changes the day of the event.
-- [ ] Make sure to get any dietary requirements from HospitalRun volunteers who haven't registered & count them in the final numbers
+- [ ] Make sure to get any dietary requirements from any HospitalRun volunteers who haven't registered & count them in the final numbers

--- a/resources/checklist.md
+++ b/resources/checklist.md
@@ -51,13 +51,41 @@ Catering Volunteer:
 ## 2 days before the event:
 
 Attendee Volunteer:
-- [ ] Send an email to the attendees to remind them of the location and that they should bring their device
+- [ ] Send an email to the attendees to remind them of the location and that they should bring their device ([there is a pre-event email template here](https://github.com/HospitalRun/events/resources/pre-event_email.md))
 
 
+## Day of the Event
 
-## Days of the Event
+Venue Volunteer:
 
-##### Agenda
+ - [ ] Make sure you have the wifi password and know the location of the restrooms
+ - [ ] Make sure the room is set up accordingly
+ - [ ] Test the A/V equipment and make sure you can run slides
+ - [ ] Make sure you know where to go and who to call in case of emergency
+ 
+ Catering Volunteer:
+ 
+ - [ ] Make sure you know what food is coming and when
+ - [ ] Pick up any last minute items
+ - [ ] Setup food as it arrives, make sure area is cleaned up throughout the event
+ - [ ] Make sure food for dietary restrictions is clearly marked so those who need it can easily find it
+ - [ ] Chill drinks before the event, and keep the cooler stocked
+  
+ Emcee Volunteer:
+ 
+ - [ ] Make sure you know the agenda and how things will go
+ - [ ] At the start of the event, make sure you announce some housekeeping items (wifi password, restroom locations, Code of Conduct reminder, anything else specific for the event)
+ - [ ] Be sure to point out the other HospitalRun volunteers so people can ask questions of them if needed
+ - [ ] Introduce yourself individually a lot, since you're the face of the event
+ 
+ Attendee Coordinator Volunteer:
+ 
+ - [ ] Make sure you have the check in list to checking people in
+ - [ ] If there are any handouts, nametags, or stickers to give at registration, make sure you have those ready
+  
+  
+
+##### Hackathon Agenda
 
 | Time | Activity |
 |---|---|

--- a/resources/checklist.md
+++ b/resources/checklist.md
@@ -6,20 +6,32 @@
 
 **In conjunction with:** (Conference and website, if applicable)
 
+---------
+
+
 ## Volunteer Roles
 
- - Venue - responsible for all venue-related things, securing a proper location: TBD
- - Catering - responsible for all catering-related things, securing food and drinks: TBD
- - Emcee - responsible for making announcements, welcoming everyone, keeping the event on track: TBD
- - Attendee Coordination - responsible for setting up registration, communicating with attendees before event: TBD
+There are 4 volunteer roles:
+
+ - Venue - responsible for all venue-related things, securing a proper location: @TBD
+ - Catering - responsible for all catering-related things, securing food and drinks: @TBD
+ - Emcee - responsible for making announcements, welcoming everyone, keeping the event on track: @TBD
+ - Attendee Coordination - responsible for setting up registration, communicating with attendees before event: @TBD
 
 
 ## Catering Info
 
-- Food delivery details: TBD
+### Friday
+- Food delivery details (*lunch*): TBD
+- Food delivery details (*Dinner*): TBD
 - Sodas: TBD
 - Paper goods: TBD
 
+### Saturday
+- Food delivery details (*Lunch*): TBD
+- Food delivery details (*Dinner*): TBD
+- Sodas: TBD
+- Paper goods: TBD
 
 ==========
 
@@ -54,34 +66,34 @@ Attendee Volunteer:
 - [ ] Send an email to the attendees to remind them of the location and that they should bring their device ([there is a pre-event email template here](https://github.com/HospitalRun/events/resources/pre-event_email.md))
 
 
-## Day of the Event
+## Day of the event
 
-Venue Volunteer:
+**Venue Volunteer:**
 
  - [ ] Make sure you have the wifi password and know the location of the restrooms
  - [ ] Make sure the room is set up accordingly
  - [ ] Test the A/V equipment and make sure you can run slides
  - [ ] Make sure you know where to go and who to call in case of emergency
  
- Catering Volunteer:
+**Catering Volunteer:**
  
  - [ ] Make sure you know what food is coming and when
  - [ ] Pick up any last minute items
  - [ ] Setup food as it arrives, make sure area is cleaned up throughout the event
  - [ ] Make sure food for dietary restrictions is clearly marked so those who need it can easily find it
  - [ ] Chill drinks before the event, and keep the cooler stocked
-  
- Emcee Volunteer:
+
+**Emcee Volunteer:**
  
  - [ ] Make sure you know the agenda and how things will go
  - [ ] At the start of the event, make sure you announce some housekeeping items (wifi password, restroom locations, Code of Conduct reminder, anything else specific for the event)
  - [ ] Be sure to point out the other HospitalRun volunteers so people can ask questions of them if needed
  - [ ] Introduce yourself individually a lot, since you're the face of the event
  
- Attendee Coordinator Volunteer:
+**Attendee Coordinator Volunteer:**
  
- - [ ] Make sure you have the check in list to checking people in
- - [ ] If there are any handouts, nametags, or stickers to give at registration, make sure you have those ready
+- [ ] Make sure you have the check in list to checking people in
+- [ ] If there are any handouts, nametags, or stickers to give at registration, make sure you have those ready
   
   
 

--- a/resources/checklist.md
+++ b/resources/checklist.md
@@ -28,7 +28,7 @@
 ## 2-3 months before event 
 
  Venue volunteer: 
- - [ ] Find a venue. [Venue requirements are here]()
+ - [ ] Find a venue. [Venue requirements are here](https://github.com/HospitalRun/events/resources/venue_requirements.md)
  - [ ] Confirm date 
  - [ ] Confirm with interested volunteers that they are willing and able to attend on that date 
  - [ ] **Site visit, if possible.** If you're local, and if it's possible, a quick check of the site to confirm it meets our needs, and so you can envision where things will be set up
@@ -46,7 +46,7 @@ Attendee Coordinator volunteer:
 ## 3-5 days before event
 
 Catering Volunteer:
-- [ ] Finalize catering, sodas, paper goods based on registration numbers ([catering requirements are here]())
+- [ ] Finalize catering, sodas, paper goods based on registration numbers ([catering requirements are here](https://github.com/HospitalRun/events/resources/catering_requirements.md))
 
 ## 2 days before the event:
 

--- a/resources/checklist.md
+++ b/resources/checklist.md
@@ -1,0 +1,82 @@
+# Hackathon Organizer Checklist
+
+**Event Dates:** TBD
+
+**Location Address:** TBD
+
+**In conjunction with:** (Conference and website, if applicable)
+
+## Volunteer Roles
+
+ - Venue - responsible for all venue-related things, securing a proper location: TBD
+ - Catering - responsible for all catering-related things, securing food and drinks: TBD
+ - Emcee - responsible for making announcements, welcoming everyone, keeping the event on track: TBD
+ - Attendee Coordination - responsible for setting up registration, communicating with attendees before event: TBD
+
+
+## Catering Info
+
+- Food delivery details: TBD
+- Sodas: TBD
+- Paper goods: TBD
+
+
+==========
+
+# TODO
+
+## 2-3 months before event 
+
+ Venue volunteer: 
+ - [ ] Find a venue. [Venue requirements are here]()
+ - [ ] Confirm date 
+ - [ ] Confirm with interested volunteers that they are willing and able to attend on that date 
+ - [ ] **Site visit, if possible.** If you're local, and if it's possible, a quick check of the site to confirm it meets our needs, and so you can envision where things will be set up
+ - [ ] Send calendar invite to interested volunteers 
+
+## 1-2 months before event
+
+Attendee Coordinator volunteer:
+- [ ] Set up registration page through Google
+- [ ] Tweet about the event
+- [ ] Email local tech meetup groups and student groups as part of outreach and diversity efforts
+- [ ] Other outreach and promotion as needed
+
+
+## 3-5 days before event
+
+Catering Volunteer:
+- [ ] Finalize catering, sodas, paper goods based on registration numbers ([catering requirements are here]())
+
+## 2 days before the event:
+
+Attendee Volunteer:
+- [ ] Send an email to the attendees to remind them of the location and that they should bring their device
+
+
+
+## Days of the Event
+
+##### Agenda
+
+| Time | Activity |
+|---|---|
+| **Friday** | |
+| 9:00 am | Ember overview (with [@embersherpa](https://twitter.com/embersherpa)) & getting local dev environments setup |
+| 11:00 am | [@tangollama](https://github.com/tangollama) short talk about what HospitalRun is and why we are building it |
+| 12:00 pm | Lunch |
+| 1:00 pm | [Work on open `help-wanted` issues](https://github.com/HospitalRun/hospitalrun-frontend/projects/1) |
+| 6:00 pm | Dinner |
+| 7:00 pm | Day one over |
+| **Saturday** | |
+| 10:00 am | [Work on open `help-wanted` issues](https://github.com/HospitalRun/hospitalrun-frontend/projects/1) |
+| 12:00 pm | Lunch |
+| 1:00 pm | [Work on open `help-wanted` issues](https://github.com/HospitalRun/hospitalrun-frontend/projects/1) |
+| 6:00 pm | Dinner |
+| 7:00 pm | Day two over (thanks for joining us! :heart: :tada:) |
+
+## 1-2 days after event
+
+Volunteer Coordinator:
+- [ ] Email + survey to people who attended the event to thank them for participating and to see how the next one can be better
+

--- a/resources/pre-event_email.md
+++ b/resources/pre-event_email.md
@@ -1,0 +1,33 @@
+## Template for sending out pre-event emails to attendees
+
+Hello!
+
+Here's a friendly reminder that you're registered to attend the HopsitalRun hackathon on [DATES]! 
+
+We have a few extra tickets to share, so please feel free to invite your friends to join us.
+
+**A few points of note** before you get here:
+- don't forget your laptop, as most of our work will be hands-on hacking
+- the venue is wheelchair accessible, and [there are gender-neutral bathrooms available]
+- most of our work will be with Ember.js, so if you're not familiar, there are some great [Getting Started Guides on the Ember.js site](https://guides.emberjs.com/v2.11.0/). We encourage you to take a look before you get to the event, so you can hit the ground running!
+- [INCLUDE ANYTHING SPECIAL ABOUT PARKING, GETTING INTO THE BUILDING, ETC]
+
+
+**What can you expect?**
+
+Friday, we will be giving an overview of Ember, as well as the goals of HospitalRun. We will then start working on issues with the `help-wanted` label. We'll end the day with dinner, and should be finished around 7:00 pm.
+
+Saturday, we'll jump in and continue working where we left off on Friday. We'll keep going until dinner, then we'll close it out with a grand send off on Saturday evening.
+ 
+
+**Details:**
+
+When: [DATES, TIMES]
+
+Where: [PLACE]
+
+If you have any questions before the event, please let us know!
+
+Sincerely,
+
+The HospitalRun Team

--- a/resources/venue_requirements.md
+++ b/resources/venue_requirements.md
@@ -1,0 +1,26 @@
+### Venue Requirements
+
+Good places to start include coode schools and coworking spaces. Libraries and unique spaces are also worth researching. Check Meetup.com for locations of local tech events; these companies and spaces would likely be open to hosting something.
+
+These are our basic needs for an event. We estimate about 20 people in attendance.
+
+- Tables and chairs for everyone to have a space to hack
+- Wifi that can take a bit of a beating
+- Outlets for power adapters
+- AV equipment, such as a mic and projector
+- Availability all day Friday and Saturday (flexible)
+- A refrigerator or access to coolers for chilling drinks
+- Ability to bring in food and drinks (or some way to cater the event with light snacks)
+- Wheelchair accessibility
+- Public access is ok
+
+We also want to find out:
+- Is it ok that the event is open to the public?
+- Are there any locked doors or security measures attendees will have to go through to get there?
+- What's the parking situation?
+- Will we be able to get the wifi password and codes for restrooms?
+- Are there gender-neutral bathrooms available?
+
+Other research before nailing down a date with the venue:
+- Are there any major events happening nearby? Sporting events, concerts, anything else that would make parking and/or traveling to the event a major hassle.
+- Are there other tech events happening that weekend that might pull people away?


### PR DESCRIPTION
A few months ago, I had a chat with @jglovier about helping clarify logistics around planning a HospitalRun hackathon. This PR addresses issue #1 and attempts to make that daunting task a wee bit easier. :blush:

It includes a *first pass* at:

 - A master checklist that can be used to plan each hackathon event, with a sample agenda based on previous HospitalRun hackathons
 - Clarification of the 4 roles that can be split up to make planning less of a burden for one person
 - Separate docs for listing venue and catering requirements, and a pre-event email template

Obviously this is just a starting point and should be iterated on as you go, and as the hackathons evolve over time. :smile: Hope it helps! 